### PR TITLE
chore: turn off access log

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -7,7 +7,8 @@ events {
 }
 
 http {
-    server_tokens off;  
+    server_tokens off;
+    access_log off;
 
     map $arg_transport $is_transportportal {
         default 0;


### PR DESCRIPTION
Denne nginxen produserer etterhvert ganske mye logg, fra helt legitim trafikk.
Vi bruker normalt loadbalancer-loggen i GCP til å undersøke trafikklogg, kan heller skrus på ved behov.