### PR TITLE
chore: don't redirect about-registration

### DIFF
--- a/nginx-prod.conf
+++ b/nginx-prod.conf
@@ -584,7 +584,7 @@ http {
             proxy_pass http://static-rdf-nginx:8080;
         }
 
-        location ~* (^/(nb|nn|en)/?)|(^/?$)|(^/(about|catalogs|contact|data-hunter|sparql|docs|robots\.txt|sitemap\.xml|manifest\.json|favicon\.ico|icon\d\.(svg|png)|apple-icon\.png|web-app-manifest)) {
+        location ~* (^/(nb|nn|en)/?)|(^/?$)|(^/(?!about-registration/?$)(about|catalogs|contact|data-hunter|sparql|docs|robots\.txt|sitemap\.xml|manifest\.json|favicon\.ico|icon\d\.(svg|png)|apple-icon\.png|web-app-manifest)) {
             location ~* (^/(nb|nn|en|robots\.txt|sitemap\.xml|manifest\.json|favicon\.ico|icon\d\.(svg|png)|apple-icon\.png|web-app-manifest)$)|(^/?$) {
                 if ($redirected != 1) {
                     return 303 https://data.norge.no$request_uri;


### PR DESCRIPTION
Ignorerer about-registration i regex slik at pathen håndteres av default location (/) - fdk-portal.