### PR TITLE
fix: narrow apis redirect regex

### DIFF
--- a/nginx-prod.conf
+++ b/nginx-prod.conf
@@ -188,7 +188,7 @@ http {
             return 301 https://data.norge.no/api/data-services;
         }
 
-        location ~* /apis(.*) {
+        location ~* ^/apis(.*) {
             return 301 https://data.norge.no/data-services$1;
         }
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -175,7 +175,7 @@ http {
             return 301 https://${host}/api/data-services;
         }
 
-        location ~* /apis(.*) {
+        location ~* ^/apis(.*) {
             return 301 https://${host}/data-services$1;
         }
 


### PR DESCRIPTION
Prøver å fikse denne bugen: https://digdir.slack.com/archives/C07ARBDG7D2/p1772795740764479?thread_ts=1772792181.889409&cid=C07ARBDG7D2

Nåværende regex gjør at alle paths som inneholder `/apis` blir redirecta til `/data-services`. Denne fiksen gjør slik at kun paths som **starter med** `/apis` treffer.